### PR TITLE
2 SP + custom spawn points support for odr

### DIFF
--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -3546,7 +3546,7 @@
             }
         },
         "Underneath Drogyga": {
-            "default_node": null,
+            "default_node": "Start Point",
             "valid_starting_location": false,
             "extra": {
                 "total_boundings": {
@@ -4193,6 +4193,21 @@
                             }
                         }
                     }
+                },
+                "Start Point": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -1615.0,
+                        "y": 9330.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "connections": {}
                 }
             }
         },

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -3547,7 +3547,7 @@
         },
         "Underneath Drogyga": {
             "default_node": "Start Point",
-            "valid_starting_location": false,
+            "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
                     "x1": -2000.0,
@@ -4207,7 +4207,15 @@
                         "default"
                     ],
                     "extra": {},
-                    "connections": {}
+                    "connections": {
+                        "Left of Grapple Blocks": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -643,6 +643,7 @@ Extra - asset_id: collision_camera_006
 
 ----------------
 Underneath Drogyga
+(Valid Starting Location)
 Extra - total_boundings: {'x1': -2000.0, 'x2': 1100.0, 'y1': 7600.0, 'y2': 10250.0}
 Extra - polygon: [[1100.0, 10250.0], [-2000.0, 10250.0], [-2000.0, 7600.0], [1100.0, 7600.0]]
 Extra - asset_id: collision_camera_007
@@ -737,6 +738,8 @@ Extra - asset_id: collision_camera_007
 
 > Start Point; Heals? False; Spawn Point
   * Layers: default
+  > Left of Grapple Blocks
+      Trivial
 
 ----------------
 Teleport to Ferenia

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -735,6 +735,9 @@ Extra - asset_id: collision_camera_007
               After Drogyga and Perform WBJ
               Spider Magnet or Lay Cross Bomb
 
+> Start Point; Heals? False; Spawn Point
+  * Layers: default
+
 ----------------
 Teleport to Ferenia
 (Valid Starting Location)

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -14215,7 +14215,7 @@
             }
         },
         "Central Unit Access": {
-            "default_node": null,
+            "default_node": "Start Point",
             "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
@@ -14244,7 +14244,23 @@
                 ],
                 "asset_id": "collision_camera_038_A"
             },
-            "nodes": {}
+            "nodes": {
+                "Start Point": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 11530.739241265557,
+                        "y": 5049.820062977958,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "connections": {}
+                }
+            }
         },
         "Purple EMMI Introduction": {
             "default_node": "Start Point",

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -14249,15 +14249,18 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 11530.739241265557,
-                        "y": 5049.820062977958,
+                        "x": 10600.0,
+                        "y": 5100.0,
                         "z": 0.0
                     },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "start_point_actor_name": "SP_Checkpoint_CentralUnit",
+                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
+                    },
                     "connections": {}
                 }
             }

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -2822,6 +2822,9 @@ Central Unit Access
 Extra - total_boundings: {'x1': 9450.0, 'x2': 11550.0, 'y1': 2600.0, 'y2': 5900.0}
 Extra - polygon: [[11550.0, 5900.0], [9450.0, 5900.0], [9450.0, 2600.0], [11550.0, 2600.0]]
 Extra - asset_id: collision_camera_038_A
+> Start Point; Heals? False; Spawn Point
+  * Layers: default
+
 ----------------
 Purple EMMI Introduction
 (Valid Starting Location)

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -2824,6 +2824,8 @@ Extra - polygon: [[11550.0, 5900.0], [9450.0, 5900.0], [9450.0, 2600.0], [11550.
 Extra - asset_id: collision_camera_038_A
 > Start Point; Heals? False; Spawn Point
   * Layers: default
+  * Extra - start_point_actor_name: SP_Checkpoint_CentralUnit
+  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
 
 ----------------
 Purple EMMI Introduction


### PR DESCRIPTION
Added two start points for the plando and a dirty way to create these start points via odr.
"dirty" because it will create multiple spawn points at the same location if they referenced multiple times but this shouldn't be an issue for the plando.